### PR TITLE
Asana integration

### DIFF
--- a/.github/workflows/asana-sync.yml
+++ b/.github/workflows/asana-sync.yml
@@ -1,0 +1,26 @@
+name: Asana Sync
+
+on:
+  pull_request_review:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - review_requested
+
+jobs:
+  sync:
+    if: vars.ASANA_PR_PROJECT_ID != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: duckduckgo/action-asana-sync@v11
+        with:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
+          ASANA_PROJECT_ID: ${{ vars.ASANA_PR_PROJECT_ID }}
+          GITHUB_PAT: ${{ secrets.GH_RO_PAT }}
+          ASSIGN_PR_AUTHOR: "true"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,6 +34,13 @@ jobs:
           echo "Applying label: $LABEL"
           gh pr edit "$PR_URL" --add-label "$LABEL"
 
+      - name: Request review for major updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "$PR_URL" --add-reviewer "muodov"
+
       - name: Enable auto-merge for patch & minor updates
         if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes; no application runtime, auth, or data paths. Requires repo secrets/vars and correct `pull_request_target` permissions for the Asana action.
> 
> **Overview**
> Adds a new **Asana Sync** GitHub Actions workflow that runs on PR lifecycle events and reviews, using `duckduckgo/action-asana-sync` when `ASANA_PR_PROJECT_ID` is set. It wires Asana tokens/workspace/project and assigns tasks to the PR author.
> 
> Updates **Dependabot auto-merge** so **semver-major** Dependabot PRs no longer only exit early from labeling—they now automatically request review from `muodov`, while patch/minor behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86df482a22c852df1c2aa599e4a0b6dc78407d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->